### PR TITLE
nvim support and Go dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Run `install.sh` and get going.
 - ZSH
 - `vundle` plugin manager for Vim. ([Reference](https://github.com/VundleVim/Vundle.vim/tree/b255382d6242d7ea3877bf059d2934125e0c4d95#quick-start))
 - `oh-my-zsh` for managing ZSH. ([Reference](https://ohmyz.sh/#install))
+- `nodejs` for the language server configurations for the `coc.vim` plugin
+    - NOTE: The default master branch for `coc.vim` does not come with precompiled binaries, unlike the `release` branch. The vim plugin manager I use (`vundle`) unfortunately does not support pinning branches or tags at the moment. A workaround is to manually compile the necessary dependencies using `yarn build && yarn install` from `~/.vim/bundle/coc.nvim`, or manually check out a different branch.
+
+##### To use coc.vim
+- `gopls` for the Go language server
 
 #### References
 Hugely inspired by [Zach Holman's dotfiles](https://github.com/holman/dotfiles)

--- a/install.sh
+++ b/install.sh
@@ -19,5 +19,7 @@ ln $DOTFILES_ROOT/git/.gitconfig.local.symlink ~/.gitconfig
 ln $DOTFILES_ROOT/psql/.psqlrc.symlink ~/.psqlrc
 
 ln $DOTFILES_ROOT/vim/.vimrc.symlink ~/.vimrc
+ln $DOTFILES_ROOT/vim/coc-settings.json ~/.config/nvim/coc-settings.json
+ln $DOTFILES_ROOT/vim/init.vim ~/.config/nvim/init.vim
 
 ln $DOTFILES_ROOT/zsh/.zshrc.local.symlink ~/.zshrc

--- a/vim/.vimrc.symlink
+++ b/vim/.vimrc.symlink
@@ -15,10 +15,19 @@ call vundle#begin()
     "https://github.com/junegunn/fzf/blob/master/README-VIM.md
     Plugin 'junegunn/fzf'
 
-    "https://github.com/tpope/vim-commentary"
+    "https://github.com/tpope/vim-commentary
     Plugin 'https://tpope.io/vim/commentary.git'
+
+    " https://github.com/neoclide/coc.nvim
+    Plugin 'neoclide/coc.nvim'
+
+    "https://github.com/fatih/vim-go
+    Plugin 'fatih/vim-go'
 call vundle#end() "required
 filetype plugin indent on "required
+
+"Remap leader
+let mapleader = ","
 
 "Remap most used NERDTree commands"
 nnoremap <Leader>n :NERDTreeToggle<CR>
@@ -31,6 +40,27 @@ nnoremap <c-j> <c-w>j
 nnoremap <c-k> <c-w>k
 nnoremap <c-l> <c-w>l
 nnoremap <c-h> <c-w>h
+
+"Automatically write the content of the buffer if you call :make
+"Especially useful for :GoBuild, saves an explicit write operation
+set autowrite
+
+"Remap vim-go commands
+autocmd FileType go nmap <leader>b  <Plug>(go-build)
+autocmd FileType go nmap <leader>r  <Plug>(go-run)
+map <C-n> :cnext<CR>
+map <C-m> :cprevious<CR>
+nnoremap <leader>a :cclose<CR>
+
+"g:go_fmt_autosave is enabled by default
+let g:go_fmt_command = "goimports"
+
+" GoTo code navigation.
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gr <Plug>(coc-references)
+
 
 "Show cursor position"
 set ruler

--- a/vim/coc-settings.json
+++ b/vim/coc-settings.json
@@ -1,0 +1,12 @@
+{
+    "languageserver": {
+        "golang": {
+            "command": "gopls",
+            "rootPatterns": ["go.mod"],
+            "filetypes": ["go"],
+            "initializationOptions": {
+                "usePlaceholders": true
+            }
+        }
+    }
+}

--- a/vim/init.vim
+++ b/vim/init.vim
@@ -1,0 +1,3 @@
+set runtimepath^=~/.vim runtimepath+=~/.vim/after
+let &packpath = &runtimepath
+source ~/.vimrc


### PR DESCRIPTION
- Add neovim configuration. Source is still vimrc
- Build, run, test, goto def support for Go using vim-go and coc.vim